### PR TITLE
CI Testing Improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: required
 language: python
 python:
@@ -12,14 +12,10 @@ branches:
 addons:
   chrome: stable
   firefox: latest
-  sauce_connect:
-    sauce_connect: true
-  apt:
-    packages:
-      # This is required to run new chrome on old trusty
-      - libnss3
+  sauce_connect: true
 
 before_install:
+  - "sysctl kernel.unprivileged_userns_clone=1"
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3

--- a/conftest.py
+++ b/conftest.py
@@ -20,6 +20,7 @@ from test_setup.processes import (
     launch_pywb,
 )
 from test_setup.util import has_parent
+from test_setup.configurations import set_selenium_driver_timeouts
 
 if TYPE_CHECKING:
     from _pytest.fixtures import SubRequest
@@ -155,6 +156,7 @@ def firefox_driver(request: "SubRequest") -> Firefox:
         capabilities=dict(marionette=True, acceptInsecureCerts=True),
         firefox_profile=ffp,
     )
+    set_selenium_driver_timeouts(driver)
     request.cls.driver = driver
     yield driver
     driver.close()
@@ -169,6 +171,7 @@ def safari_driver(request: "SubRequest") -> Union[Remote, Safari]:
         executor = RemoteConnection(SAUCE_HUB_URL, resolve_ip=False)
         driver = Remote(desired_capabilities=SAUCE_SAFARI, command_executor=executor)
 
+    set_selenium_driver_timeouts(driver)
     request.cls.driver = driver
     yield driver
     driver.close()
@@ -182,6 +185,7 @@ def edge_driver(request: "SubRequest") -> Union[Remote, Edge]:
     else:
         executor = RemoteConnection(SAUCE_HUB_URL, resolve_ip=False)
         driver = Remote(desired_capabilities=SAUCE_EDGE, command_executor=executor)
+    set_selenium_driver_timeouts(driver)
     request.cls.driver = driver
     yield driver
     driver.close()

--- a/test_setup/__init__.py
+++ b/test_setup/__init__.py
@@ -1,17 +1,62 @@
-from .configurations import *
-from .constants import *
-from .generate_tests import *
-from .loaders import *
-from .processes import *
-from .util import *
-from .wrtest import *
-
-__all__ = (
-    configurations.__all__
-    + constants.__all__
-    + generate_tests.__all__
-    + loaders.__all__
-    + processes.__all__
-    + util.__all__
-    + wrtest.__all__
+from .configurations import set_selenium_driver_timeouts
+from .constants import (
+    WAITS,
+    CHROME_EXE,
+    FIREFOX_EXE,
+    SAFARI_EXE,
+    OPERA_EXE,
+    EDGE_EXE,
+    TRAVIS_TUNNEL_ID,
+    SAUCE_HUB_URL,
+    SAUCE_EDGE,
+    SAUCE_SAFARI,
+    HAVE_PYWB,
+    PYWB_SKIP_REASON,
+    USE_SAUCE,
+    SAUCE_SKIP_REASON,
 )
+from .generate_tests import gen
+from .loaders import load_file, load_javascript, load_manifest
+from .processes import (
+    launch_chrome,
+    launch_chromium,
+    launch_opera,
+    launch_wr_player,
+    process_reaper,
+    launch_pywb,
+)
+from .util import has_parent
+from .wrtest import WRAutoTestTimeOut, WRTest, BaseSimpleChromeTest, BaseWRSeleniumTest
+
+__all__ = [
+    "set_selenium_driver_timeouts",
+    "WAITS",
+    "CHROME_EXE",
+    "FIREFOX_EXE",
+    "SAFARI_EXE",
+    "OPERA_EXE",
+    "EDGE_EXE",
+    "TRAVIS_TUNNEL_ID",
+    "SAUCE_HUB_URL",
+    "SAUCE_EDGE",
+    "SAUCE_SAFARI",
+    "HAVE_PYWB",
+    "PYWB_SKIP_REASON",
+    "USE_SAUCE",
+    "SAUCE_SKIP_REASON",
+    "gen",
+    "load_file",
+    "load_javascript",
+    "load_manifest",
+    "launch_chrome",
+    "launch_chromium",
+    "launch_opera",
+    "launch_wr_player",
+    "process_reaper",
+    "launch_pywb",
+    "has_parent",
+    "WRAutoTestTimeOut",
+    "WRTest",
+    "BaseSimpleChromeTest",
+    "BaseWRSeleniumTest",
+]

--- a/test_setup/configurations.py
+++ b/test_setup/configurations.py
@@ -1,53 +1,12 @@
 """Module containing test setup methods"""
-from pathlib import Path
-from typing import List, TYPE_CHECKING, Dict, Union
+from selenium.webdriver.remote.webdriver import WebDriver
 
-from .loaders import load_manifest, load_file
-
-if TYPE_CHECKING:
-    from py._path.local import LocalPath
-    from _pytest.fixtures import SubRequest
-    from _pytest.python import Metafunc
-    from .wrtest import WRTest
-
-__all__ = ["autowire_test", "configure_test"]
+__all__ = ["set_selenium_driver_timeouts"]
 
 
-def setup_url(fixturenames: List[str], config: Dict) -> str:
-    """Constructs the correct url for the test based on the fixture name"""
-    if "wr_player" in fixturenames:
-        return (
-            f"http://localhost:8092/local/collection/"
-            f"{config.get('time')}/{config.get('url')}"
-        )
-    return f"http://localhost:8080/tests/{config.get('time')}/{config.get('url')}"
-
-
-def _default_test_setup(
-    root: Union["LocalPath", Path], fixturenames: List[str], config: Dict, cls: "WRTest"
-) -> None:
-    cls.player = (str(root / "bin/webrecorder-player"), "8092", config.get("warc-file"))
-    _js = config.get("javascript")
-    if _js:
-        cls.js = (
-            f"{load_file(root / 'test_setup' /'testUtil.js')}\n{load_file(root / _js)}"
-        )
-    cls.url = setup_url(fixturenames, config)
-    cls.chrome_opts = config.get("chrome")
-
-
-def autowire_test(metafunc: "Metafunc") -> None:
-    """Autowire a WRAutoTest."""
-    cls = metafunc.cls
-    rootdir = metafunc.config.rootdir
-    config = load_manifest(rootdir / cls.manifest)
-    _default_test_setup(rootdir, metafunc.fixturenames, config, cls)
-    metafunc.parametrize("test_name", config.get("tests"))
-
-
-def configure_test(request: "SubRequest") -> None:
-    """Configure a test using the manifest class property"""
-    mani_p = request.cls.manifest
-    rootdir = request.session.fspath
-    config = load_manifest(rootdir / mani_p)
-    _default_test_setup(rootdir, request.fixturenames, config, request.cls)
+def set_selenium_driver_timeouts(driver: WebDriver) -> None:
+    """Sets the script execution timeout to 90 seconds and the
+    page load timeout to 60 seconds
+    """
+    driver.set_script_timeout(90)
+    driver.set_page_load_timeout(60)

--- a/test_setup/constants.py
+++ b/test_setup/constants.py
@@ -1,8 +1,8 @@
 import os
-from shutil import which
-from typing import Dict, Optional, List, Union
 
 import attr
+from shutil import which
+from typing import Dict, Optional, List, Union
 
 __all__ = [
     "Waits",
@@ -18,6 +18,8 @@ __all__ = [
     "SAUCE_SAFARI",
     "HAVE_PYWB",
     "PYWB_SKIP_REASON",
+    "USE_SAUCE",
+    "SAUCE_SKIP_REASON",
 ]
 
 
@@ -51,14 +53,14 @@ def find_firefox() -> Optional[str]:
     return None
 
 
-@attr.dataclass(slots=True, frozen=True)
+@attr.dataclass(frozen=True)
 class Waits(object):
     """Immutable class holding the waits used in simple chrome"""
 
     load: Dict[str, str] = attr.ib(default=dict(waitUntil="load"))
     dom_load: Dict[str, str] = attr.ib(default=dict(waitUntil="documentloaded"))
     net_idle: Dict[str, str] = attr.ib(default=dict(waitUntil="networkidle0"))
-    net_almost_idle: Dict[str, str] = attr.ib(default=dict(waitUntil="networkidle1"))
+    net_almost_idle: Dict[str, str] = attr.ib(default=dict(waitUntil="networkidle2"))
 
 
 WAITS = Waits()
@@ -125,3 +127,8 @@ except ImportError:
     HAVE_PYWB = False
 
 PYWB_SKIP_REASON = "Pywb is not installed. To test using pywb, please execute 'pip install -r test-requirements.txt'"
+
+USE_SAUCE = bool(os.getenv("USE_SAUCE", False))
+
+SAUCE_SKIP_REASON = 'The environment key "USE_SAUCE" was not defined'
+

--- a/test_setup/generate_tests.py
+++ b/test_setup/generate_tests.py
@@ -6,7 +6,7 @@ from jinja2 import Template
 
 from .loaders import load_manifest
 
-__all__ = ["gen"]
+__all__ = ["gen", "load_test_setup_str", "load_test_js_str", "load_template"]
 
 
 def load_test_setup_str(test_setup_dir) -> str:

--- a/test_setup/templates/chromeBasedTests.py.j2
+++ b/test_setup/templates/chromeBasedTests.py.j2
@@ -13,7 +13,7 @@ class TestPywbOpera(BaseSimpleChromeTest):
     @pytest.mark.parametrize("test_name", TEST_LIST)
     async def test_all(self, test_name: str) -> None:
         """Default test method, called once per each test listed in the manifest"""
-        replay_frame = await self.goto_test(self.waits.net_idle)
+        replay_frame = await self.goto_test()
         try:
             async with timeout(self.test_to):
                 results = await replay_frame.evaluate(f"{test_name}()")
@@ -39,7 +39,7 @@ class TestPywbChromium(BaseSimpleChromeTest):
     @pytest.mark.parametrize("test_name", TEST_LIST)
     async def test_all(self, test_name: str) -> None:
         """Default test method, called once per each test listed in the manifest"""
-        replay_frame = await self.goto_test(self.waits.net_idle)
+        replay_frame = await self.goto_test()
         try:
             async with timeout(self.test_to):
                 results = await replay_frame.evaluate(f"{test_name}()")
@@ -66,7 +66,7 @@ class TestPywbChrome(BaseSimpleChromeTest):
     @pytest.mark.parametrize("test_name", TEST_LIST)
     async def test_all(self, test_name: str) -> None:
         """Default test method, called once per each test listed in the manifest"""
-        replay_frame = await self.goto_test(self.waits.net_idle)
+        replay_frame = await self.goto_test()
         try:
             async with timeout(self.test_to):
                 results = await replay_frame.evaluate(f"{test_name}()")
@@ -78,7 +78,6 @@ class TestPywbChrome(BaseSimpleChromeTest):
         assert results
 
 
-@pytest.mark.skipif(not HAVE_PYWB, reason=PYWB_SKIP_REASON)
 @pytest.mark.skipif(OPERA_EXE is None, reason="Opera Is Not Installed")
 @pytest.mark.wrplayertest
 @pytest.mark.operatest
@@ -94,7 +93,7 @@ class TestWRPlayerOpera(BaseSimpleChromeTest):
     @pytest.mark.parametrize("test_name", TEST_LIST)
     async def test_all(self, test_name: str) -> None:
         """Default test method, called once per each test listed in the manifest"""
-        replay_frame = await self.goto_test(self.waits.net_idle)
+        replay_frame = await self.goto_test()
         try:
             async with timeout(self.test_to):
                 results = await replay_frame.evaluate(f"{test_name}()")
@@ -106,7 +105,6 @@ class TestWRPlayerOpera(BaseSimpleChromeTest):
         assert results
 
 
-@pytest.mark.skipif(not HAVE_PYWB, reason=PYWB_SKIP_REASON)
 @pytest.mark.wrplayertest
 @pytest.mark.chromiumtest
 @pytest.mark.usefixtures("wr_player", "chromium_page")
@@ -121,7 +119,7 @@ class TestWRPlayerChromium(BaseSimpleChromeTest):
     @pytest.mark.parametrize("test_name", TEST_LIST)
     async def test_all(self, test_name: str) -> None:
         """Default test method, called once per each test listed in the manifest"""
-        replay_frame = await self.goto_test(self.waits.net_idle)
+        replay_frame = await self.goto_test()
         try:
             async with timeout(self.test_to):
                 results = await replay_frame.evaluate(f"{test_name}()")
@@ -133,7 +131,6 @@ class TestWRPlayerChromium(BaseSimpleChromeTest):
         assert results
 
 
-@pytest.mark.skipif(not HAVE_PYWB, reason=PYWB_SKIP_REASON)
 @pytest.mark.skipif(CHROME_EXE is None, reason="Chrome Is Not Installed")
 @pytest.mark.wrplayertest
 @pytest.mark.chrometest
@@ -149,7 +146,7 @@ class TestWRPlayerChrome(BaseSimpleChromeTest):
     @pytest.mark.parametrize("test_name", TEST_LIST)
     async def test_all(self, test_name: str) -> None:
         """Default test method, called once per each test listed in the manifest"""
-        replay_frame = await self.goto_test(self.waits.net_idle)
+        replay_frame = await self.goto_test()
         try:
             async with timeout(self.test_to):
                 results = await replay_frame.evaluate(f"{test_name}()")

--- a/test_setup/templates/seleniumBasedTests.py.j2
+++ b/test_setup/templates/seleniumBasedTests.py.j2
@@ -36,6 +36,7 @@ class TestWRPlayerFireFox(BaseWRSeleniumTest):
         assert self.driver.execute_async_script(to_inject)
 
 
+@pytest.mark.skipif(not USE_SAUCE, reason=SAUCE_SKIP_REASON)
 @pytest.mark.skipif(
     TRAVIS_TUNNEL_ID is None and SAFARI_EXE is None,
     reason="Safari Testing On Non-OSX Machines Requires Travis",
@@ -58,6 +59,7 @@ class TestPywbSafari(BaseWRSeleniumTest):
         assert self.driver.execute_async_script(to_inject)
 
 
+@pytest.mark.skipif(not USE_SAUCE, reason=SAUCE_SKIP_REASON)
 @pytest.mark.skipif(
     TRAVIS_TUNNEL_ID is None and SAFARI_EXE is None,
     reason="Safari Testing On Non-OSX Machines Requires Travis",
@@ -80,6 +82,7 @@ class TestWRPlayerSafari(BaseWRSeleniumTest):
         assert self.driver.execute_async_script(to_inject)
 
 
+@pytest.mark.skipif(not USE_SAUCE, reason=SAUCE_SKIP_REASON)
 @pytest.mark.skipif(
     TRAVIS_TUNNEL_ID is None and EDGE_EXE is None,
     reason="Edge Testing On Non-Windows Machines Requires Travis",
@@ -102,6 +105,7 @@ class TestPywbEdge(BaseWRSeleniumTest):
         assert self.driver.execute_async_script(to_inject)
 
 
+@pytest.mark.skipif(not USE_SAUCE, reason=SAUCE_SKIP_REASON)
 @pytest.mark.skipif(
     TRAVIS_TUNNEL_ID is None and EDGE_EXE is None,
     reason="Edge Testing On Non-Windows Machines Requires Travis",

--- a/test_setup/templates/testHeader.py.j2
+++ b/test_setup/templates/testHeader.py.j2
@@ -4,6 +4,7 @@ import pytest
 import asyncio
 from asyncio import TimeoutError
 from async_timeout import timeout
+from typing import {% if chromeopts %}Dict,{% endif -%} List, Tuple
 from test_setup.constants import (
     CHROME_EXE,
     OPERA_EXE,
@@ -13,6 +14,8 @@ from test_setup.constants import (
     HAVE_PYWB,
     PYWB_SKIP_REASON,
     TRAVIS_TUNNEL_ID,
+    USE_SAUCE,
+    SAUCE_SKIP_REASON
 )
 from test_setup.loaders import load_file
 from test_setup.wrtest import (
@@ -22,20 +25,24 @@ from test_setup.wrtest import (
 )
 
 {% if has_js %}
-TEST_JS = (
+TEST_JS: str = (
     {{ test_util }}
     + "\n"
     + {{ js }}
 )
 {% else -%}
-TEST_JS = {{ test_util }} + "\n"
+TEST_JS: str = {{ test_util }} + "\n"
 {% endif -%}
 {% if chromeopts %}
-CHROME_OPTS = {{ chromeopts }}
+CHROME_OPTS: Dict[str, str]  = {{ chromeopts }}
 {% endif -%}
-TEST_LIST = {{ test_list }}
-PLAYER_INFO = {{ player_info }}
-PLAYER_URL = "{{ player_url }}"
-PYWB_URL = "{{ pywb_url }}"
+TEST_LIST: List[str] = {{ test_list }}
+PLAYER_INFO: Tuple[str, str, str] = (
+    "{{ player_info[0] }}",
+    "{{ player_info[1] }}",
+    "{{ player_info[2] }}",
+)
+PLAYER_URL: str = "{{ player_url }}"
+PYWB_URL: str = "{{ pywb_url }}"
 
 

--- a/test_setup/wrtest.py
+++ b/test_setup/wrtest.py
@@ -1,9 +1,9 @@
 from asyncio import AbstractEventLoop
-from typing import ClassVar, Optional, Dict, Tuple
-from typing import Union
 
 from selenium.webdriver.remote.webdriver import WebDriver
-from simplechrome import Page, Frame
+from simplechrome import Page, Frame, NavigationTimeoutError
+from typing import ClassVar, Dict, Tuple
+from typing import Union
 
 from .constants import Waits, WAITS
 
@@ -61,23 +61,16 @@ class BaseSimpleChromeTest(WRTest):
     page: ClassVar[Page] = None
     loop: ClassVar[AbstractEventLoop] = None
 
-    async def goto_test(self, wait: Optional[Dict[str, str]] = None) -> Frame:
+    async def goto_test(self) -> Frame:
         """
         Navigate the browser to the test page.
-        Optionally waiting for a specific browser event.
 
-        :param wait: Optional wait for event to happen
-        :type wait: WAITS
         :return: The frame containing the replayed page
         :rtype: simplechrome.Frame
         """
-        await self.page.goto(self.url, self.waits.load)
+        try:
+            await self.page.goto(self.url, self.waits.net_almost_idle)
+        except NavigationTimeoutError:
+            pass
         replay_frame = self.page.frames[1]
-        replay_frame.enable_lifecycle_emitting()
-        await replay_frame.navigation_waiter(loop=self.loop, timeout=15)
-        if wait is not None:
-            if wait == self.waits.load:
-                await replay_frame.loaded_waiter(loop=self.loop, timeout=15)
-            elif wait == self.waits.net_idle:
-                await replay_frame.network_idle_waiter(loop=self.loop, timeout=15)
         return replay_frame


### PR DESCRIPTION
Made testing use sauce-labs configurable by environment USE_SAUCE:
- If it exists then the sauce-labs tests will be enabled
- If it does not exist then the sauce-labs tests will be disabled

BaseSimpleChromeTest.goto_test now navigates to page waiting for net_almost_idle for all frames
Selenium bases tests now have the script timeout set to 90 seconds and page load timeout set to 60 seconds

travis config changes:
- dist is not xenial rather than trusty
- added "sysctl kernel.unprivileged_userns_clone=1" to before install to make Chrome/Chromium browser based tests run better